### PR TITLE
Fix worker implementation gaps and integrate Claude Agent SDK

### DIFF
--- a/apps/orchestrator/src/modules/workers/workers.controller.ts
+++ b/apps/orchestrator/src/modules/workers/workers.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Post, Delete, Body, Param, HttpCode, HttpStatus } from '@nestjs/common';
 import { WorkersService } from './workers.service';
 
 @Controller('workers')
@@ -9,5 +9,18 @@ export class WorkersController {
   async getWorkers() {
     const workers = await this.workersService.getWorkers();
     return { workers };
+  }
+
+  @Post('register')
+  @HttpCode(HttpStatus.CREATED)
+  async registerWorker(@Body() body: { workerId: string; workerType: string }) {
+    await this.workersService.registerWorker(body.workerId, body.workerType);
+    return { message: 'Worker registered successfully', workerId: body.workerId };
+  }
+
+  @Delete(':workerId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deregisterWorker(@Param('workerId') workerId: string) {
+    await this.workersService.deregisterWorker(workerId);
   }
 }

--- a/apps/worker/src/__tests__/heartbeat.service.test.ts
+++ b/apps/worker/src/__tests__/heartbeat.service.test.ts
@@ -13,7 +13,7 @@ describe('HeartbeatService', () => {
       setex: jest.fn().mockResolvedValue('OK'),
     } as any;
 
-    heartbeatService = new HeartbeatService(mockRedis, 'test-worker-1', 10);
+    heartbeatService = new HeartbeatService(mockRedis, 'test-worker-1', 'local', 10);
     jest.clearAllMocks();
     jest.useFakeTimers();
   });
@@ -76,7 +76,7 @@ describe('HeartbeatService', () => {
     });
 
     it('should use custom interval when provided', () => {
-      const customService = new HeartbeatService(mockRedis, 'test-worker-2', 5);
+      const customService = new HeartbeatService(mockRedis, 'test-worker-2', 'local', 5);
       customService.start();
 
       expect(mockRedis.setex).toHaveBeenCalledTimes(1);
@@ -177,7 +177,7 @@ describe('HeartbeatService', () => {
 
   describe('worker identification', () => {
     it('should use correct worker ID in Redis key', () => {
-      const service1 = new HeartbeatService(mockRedis, 'worker-alpha', 10);
+      const service1 = new HeartbeatService(mockRedis, 'worker-alpha', 'local', 10);
       service1.start();
 
       expect(mockRedis.setex).toHaveBeenCalledWith(
@@ -190,7 +190,7 @@ describe('HeartbeatService', () => {
     });
 
     it('should handle special characters in worker ID', () => {
-      const service = new HeartbeatService(mockRedis, 'worker-123_test.local', 10);
+      const service = new HeartbeatService(mockRedis, 'worker-123_test.local', 'local', 10);
       service.start();
 
       expect(mockRedis.setex).toHaveBeenCalledWith(
@@ -205,14 +205,14 @@ describe('HeartbeatService', () => {
 
   describe('edge cases', () => {
     it('should handle interval being null when stopping', () => {
-      const service = new HeartbeatService(mockRedis, 'test-worker', 10);
+      const service = new HeartbeatService(mockRedis, 'test-worker', 'local', 10);
 
       // Stop without starting
       expect(() => service.stop()).not.toThrow();
     });
 
     it('should clear existing interval when stopping multiple times', () => {
-      const service = new HeartbeatService(mockRedis, 'test-worker', 10);
+      const service = new HeartbeatService(mockRedis, 'test-worker', 'local', 10);
       service.start();
 
       service.stop();

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -29,6 +29,7 @@ async function main() {
       options.id,
       redis,
       process.env.QUEUE_NAME || 'claude-tasks',
+      options.type,
     );
 
     await worker.start();


### PR DESCRIPTION
## Summary

This PR addresses all critical issues with the worker implementation and fully integrates the Claude Agent SDK for actual prompt execution.

## Critical Fixes

### 🔴 Worker now executes prompts with Claude Agent SDK
- **Before**: Worker had `TODO: Submit to Claude Code API` placeholder
- **After**: Integrated actual Claude SDK `query()` function
- Properly extracts stdout, stderr, and exit codes from SDK messages
- Handles timeouts (124 exit code) and errors correctly

### 🔴 Worker sends results back to orchestrator
- **Before**: Worker returned immediately with `{ status: 'submitted' }` but never sent actual results
- **After**: Worker sends `QueueJobResult` messages to `claude-tasks-results` queue after execution
- Includes workerId, status, result/error messages, and execution time
- Orchestrator's result worker receives and processes these results

### 🟡 Task-worker assignment tracking
- **Before**: No tracking of which worker picked up which task
- **After**: QueueService listens for 'active' events and marks tasks as RUNNING
- Tasks are updated with workerId when results are processed
- Dashboard can now show worker-task relationships

### 🟡 Worker type tracking
- **Before**: Worker type was inferred from worker ID (e.g., `workerId.includes('cloud')`)
- **After**: Worker type from CLI `--type` parameter is stored in Redis
- WorkersService reads actual type from `worker:{id}:type` key
- Properly displayed in dashboard

### 🟡 Worker registration & deregistration
- **Before**: Workers only announced via heartbeat, disappeared silently after 30s
- **After**: Added explicit registration/deregistration
  - `POST /workers/register` endpoint
  - `DELETE /workers/:workerId` endpoint  
  - Worker calls `cleanup()` on shutdown to remove Redis keys

## Changes by Component

### Worker (apps/worker)
- **executor.service.ts**: Replace placeholder with real Claude SDK integration
- **worker.service.ts**: Add result queue initialization and result reporting  
- **heartbeat.service.ts**: Store worker type in Redis, add cleanup method
- **index.ts**: Pass worker type parameter from CLI to WorkerService
- **tests**: Update HeartbeatService test constructor calls

### Orchestrator (apps/orchestrator)
- **queue.service.ts**: Add QueueEvents listener to mark tasks as RUNNING on 'active' event
- **workers.service.ts**: Read worker type from Redis, add register/deregister methods
- **workers.controller.ts**: Add POST /workers/register and DELETE endpoints

## Testing

✅ All TypeScript builds pass
✅ Worker unit tests updated and passing  
✅ Orchestrator unit tests passing

## What Works Now

The worker is now **fully functional**:

1. ✅ Accepts prompts from the queue
2. ✅ Executes them using Claude Agent SDK
3. ✅ Sends results back to the orchestrator
4. ✅ Registers with proper type metadata
5. ✅ Tracks which tasks it's processing
6. ✅ Cleans up properly on shutdown

## Breaking Changes

None - this is purely adding missing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)